### PR TITLE
Improve VSCode Debug Tasks

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,10 +18,8 @@
             "request": "launch",
             "module": "mlops.nyc_taxi.start_local_pipeline",
             "args": [
-                "--build_environment",
-                "pr",
-                "--wait_for_completion",
-                "True"
+                "--build_environment=${input:build_environment}",
+                "--wait_for_completion=${input:wait_for_completion}"
             ],
             "console": "integratedTerminal"
         },
@@ -31,12 +29,32 @@
             "request": "launch",
             "module": "mlops.london_taxi.start_local_pipeline",
             "args": [
-                "--build_environment",
-                "pr",
-                "--wait_for_completion",
-                "True"
+                "--build_environment=${input:build_environment}",
+                "--wait_for_completion=${input:wait_for_completion}"
             ],
             "console": "integratedTerminal"
+        }
+    ],
+    "inputs": [
+        {
+            "id": "build_environment",
+            "type": "pickString",
+            "options": [
+                "pr",
+                "dev"
+            ],
+            "description": "The build environment (ex: pr, dev, prod)",
+            "default": "pr",
+        },
+        {
+            "id": "wait_for_completion",
+            "type": "pickString",
+            "options": [
+                "True",
+                "False"
+            ],
+            "description": "Wait for the completion of the pipeline (True/False)",
+            "default": "False",
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
             "console": "integratedTerminal"
         },
         {
-            "name": "NYC Taxi Local Pipeline",
+            "name": "Start NYC Taxi Local Pipeline",
             "type": "debugpy",
             "request": "launch",
             "module": "mlops.nyc_taxi.start_local_pipeline",
@@ -26,7 +26,7 @@
             "console": "integratedTerminal"
         },
         {
-            "name": "London Taxi Local Pipeline",
+            "name": "Start London Taxi Local Pipeline",
             "type": "debugpy",
             "request": "launch",
             "module": "mlops.london_taxi.start_local_pipeline",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,42 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Register Data Asset",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "mlops.common.register_data_asset",
+            "args": [
+                "--data_config_path",
+                "config/data_config.json"
+            ],
+            "console": "integratedTerminal"
+        },
+        {
+            "name": "NYC Taxi Local Pipeline",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "mlops.nyc_taxi.start_local_pipeline",
+            "args": [
+                "--build_environment",
+                "pr",
+                "--wait_for_completion",
+                "True"
+            ],
+            "console": "integratedTerminal"
+        },
+        {
+            "name": "London Taxi Local Pipeline",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "mlops.london_taxi.start_local_pipeline",
+            "args": [
+                "--build_environment",
+                "pr",
+                "--wait_for_completion",
+                "True"
+            ],
+            "console": "integratedTerminal"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -71,14 +71,14 @@ You can use Visual Studio Code to run and debug specific tasks related to the ML
 1. **Register Data Asset**
    - **Command:** `python -m mlops.common.register_data_asset --data_config_path config/data_config.json`
    - **Description:** Registers a data asset using the provided configuration file.
-   
+
 2. **Start NYC Taxi Local Pipeline**
-   - **Command:** `python -m mlops.nyc_taxi.start_local_pipeline --build_environment pr --wait_for_completion True`
-   - **Description:** Starts the NYC Taxi pipeline in a local environment and waits for completion.
-   
+   - **Command:** `python -m mlops.nyc_taxi.start_local_pipeline --build_environment=<environment> --wait_for_completion=<True/False>`
+   - **Description:** Starts the NYC Taxi pipeline in a local environment. You will be prompted to specify the `build_environment` and whether the pipeline should wait for completion.
+
 3. **Start London Taxi Local Pipeline**
-   - **Command:** `python -m mlops.london_taxi.start_local_pipeline --build_environment pr --wait_for_completion True`
-   - **Description:** Starts the London Taxi pipeline in a local environment and waits for completion.
+   - **Command:** `python -m mlops.london_taxi.start_local_pipeline --build_environment=<environment> --wait_for_completion=<True/False>`
+   - **Description:** Starts the London Taxi pipeline in a local environment. You will be prompted to specify the `build_environment` and whether the pipeline should wait for completion.
 
 ### How to Run
 
@@ -88,12 +88,16 @@ You can use Visual Studio Code to run and debug specific tasks related to the ML
    - `Start NYC Taxi Local Pipeline`
    - `Start London Taxi Local Pipeline`
 3. Click the green play button (`▶`) next to the dropdown to start the task.
-4. The output and any debugging information will be displayed in the **Debug Console** or **Integrated Terminal**, depending on the task configuration.
+4. For the NYC Taxi and London Taxi pipelines, you will be prompted to enter two values:
+   - **Build Environment:** Choose from `pr`, `dev`, or any other configured environments.
+   - **Wait for Completion:** Choose `True` if you want the pipeline to wait for completion before exiting, or `False` to allow it to run asynchronously.
+5. The output and any debugging information will be displayed in the **Debug Console** or **Integrated Terminal**, depending on the task configuration.
 
 ### Notes
 
 - Ensure that your environment is correctly set up and all necessary dependencies are installed before running these tasks.
-- If you encounter any issues, check the `launch.json` file in the `.vscode` directory to verify the configuration.
+- The available options for `build_environment` and `wait_for_completion` are defined in the [launch.json](.vscode/launch.json) file and can be modified to suit your project’s needs.
+- If you encounter any issues, check the [launch.json](.vscode/launch.json) file in the `.vscode` directory to verify the configuration.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ You can use Visual Studio Code to run and debug specific tasks related to the ML
    - **Command:** `python -m mlops.common.register_data_asset --data_config_path config/data_config.json`
    - **Description:** Registers a data asset using the provided configuration file.
    
-2. **NYC Taxi Local Pipeline**
+2. **Start NYC Taxi Local Pipeline**
    - **Command:** `python -m mlops.nyc_taxi.start_local_pipeline --build_environment pr --wait_for_completion True`
    - **Description:** Starts the NYC Taxi pipeline in a local environment and waits for completion.
    
-3. **London Taxi Local Pipeline**
+3. **Start London Taxi Local Pipeline**
    - **Command:** `python -m mlops.london_taxi.start_local_pipeline --build_environment pr --wait_for_completion True`
    - **Description:** Starts the London Taxi pipeline in a local environment and waits for completion.
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,39 @@ You can start training pipelines from your local computer by creating an environ
   - `python -m mlops.common.register_data_asset --data_config_path config/data_config.json`
 - Run the training pipeline under test using the module notation (for example, `python -m mlops.nyc_taxi.start_local_pipeline --build_environment pr --wait_for_completion True`)
 
+## Running Debug Tasks in VS Code
+
+You can use Visual Studio Code to run and debug specific tasks related to the MLOps pipelines. The following configurations are set up in the [launch.json](.vscode/launch.json) file, allowing you to execute various scripts with ease.
+
+### Available Debug Tasks
+
+1. **Register Data Asset**
+   - **Command:** `python -m mlops.common.register_data_asset --data_config_path config/data_config.json`
+   - **Description:** Registers a data asset using the provided configuration file.
+   
+2. **NYC Taxi Local Pipeline**
+   - **Command:** `python -m mlops.nyc_taxi.start_local_pipeline --build_environment pr --wait_for_completion True`
+   - **Description:** Starts the NYC Taxi pipeline in a local environment and waits for completion.
+   
+3. **London Taxi Local Pipeline**
+   - **Command:** `python -m mlops.london_taxi.start_local_pipeline --build_environment pr --wait_for_completion True`
+   - **Description:** Starts the London Taxi pipeline in a local environment and waits for completion.
+
+### How to Run
+
+1. Open the **Debug** panel in Visual Studio Code.
+2. Select the desired debug task from the dropdown list. The options are:
+   - `Register Data Asset`
+   - `Start NYC Taxi Local Pipeline`
+   - `Start London Taxi Local Pipeline`
+3. Click the green play button (`▶`) next to the dropdown to start the task.
+4. The output and any debugging information will be displayed in the **Debug Console** or **Integrated Terminal**, depending on the task configuration.
+
+### Notes
+
+- Ensure that your environment is correctly set up and all necessary dependencies are installed before running these tasks.
+- If you encounter any issues, check the `launch.json` file in the `.vscode` directory to verify the configuration.
+
 ## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a


### PR DESCRIPTION
Adds 3 debug tasks to launch.json: Register Data Asset, Start NYC Taxi Local Pipeline, Start London Taxi Local Pipeline

Adds information to readme on purpose of debug tasks, which are currently available, and how to run them.

[Improve VSCode Debug Tasks Story](https://dev.azure.com/CrewPoseidon/Leidos%20Provision/_boards/board/t/Leidos%20Provision%20Team/Stories?workitem=3251)